### PR TITLE
Fix `[compat]` entries in `Project.toml`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 julia = "1"
-Distributions = "0"
+Distributions = "0.16, 0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
In the General registry, we now **strongly** discourage users from having `[compat]` entries of the form:
```toml
SomePackage = "0"
```

These `[compat]` entries are problematic because they include an infinite number of breaking releases.

This pull request fixes the `[compat]` entries in the `Project.toml` file for this package.

cc: @scheinerman