### PR TITLE
Add support for Distributions 0.24

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SimpleRandom"
 uuid = "a6525b86-64cd-54fa-8f65-62fc48bdc0e8"
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
@@ -9,7 +9,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 julia = "1"
-Distributions = "0.16, 0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23"
+Distributions = "0.16, 0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
I noticed that there exists no release of SimpleRandom that officially supports Distributions 0.24 (and therefore I couldn't add it to a project where some other packages only support Distributions 0.24).

On a side note, you could add [CompatHelper](https://github.com/JuliaRegistries/CompatHelper.jl) to your repository to be notified about new breaking releases of dependencies automatically.